### PR TITLE
Submit a version-specific manifest URL to the Foundry Release API

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: 'Name of the Foundry Manifest File, either system.json or module.json'
     required: true
     default: 'module.json'
+  publicRepositoryAndBranch:
+    description: 'owner/repo/branch of the public content repository (used for protected packages, auto-detected from the manifest)'
+    required: false
+    default: 'foundryvtt-dcc/dcc-content/main'
   versionFileName:
     description: 'Name of the file in the release that contains the version number'
     required: true

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const actionToken = core.getInput('actionToken')
 const dryRun = core.getInput('dryRun')
 const foundryToken = core.getInput('foundryToken')
 const manifestFileName = core.getInput('manifestFileName')
+const publicRepositoryAndBranch = core.getInput('publicRepositoryAndBranch') || 'foundryvtt-dcc/dcc-content/main'
 const octokit = github.getOctokit(actionToken)
 const owner = github.context.payload.repository.owner.login
 const repo = github.context.payload.repository.name
@@ -67,6 +68,19 @@ async function updatePackage () {
     console.debug(dryRun)
     console.debug(dryRunBoolean)
 
+    // Foundry's Release API expects a VERSION-SPECIFIC manifest URL — not the
+    // package's own `manifest` field, which now points at a stable "latest" URL
+    // for ongoing update detection. Reconstruct the per-version URL here.
+    // Protected packages are auto-detected from the released manifest itself
+    // (their asset carries `protected: true`); their source repo is private, so
+    // the public versioned mirror in the content repo is used instead of the
+    // GitHub release asset.
+    let releaseManifestUrl = `https://github.com/${owner}/${repo}/releases/download/v${version}/${manifestFileName}`
+    if (manifestFileData.protected === true) {
+      releaseManifestUrl = `https://raw.githubusercontent.com/${publicRepositoryAndBranch}/${repo}/v${version}/${manifestFileName}`
+    }
+    console.debug(releaseManifestUrl)
+
     const foundryResponse = await fetch('https://api.foundryvtt.com/_api/packages/release_version/', {
       headers: {
         'Content-Type': 'application/json',
@@ -78,7 +92,7 @@ async function updatePackage () {
         'dry-run': dryRunBoolean,
         release: {
           version,
-          manifest: manifestFileData.manifest,
+          manifest: releaseManifestUrl,
           notes: releaseNotesUrl,
           compatibility: {
             minimum: compatibilityMinFromManifest,


### PR DESCRIPTION
## What
The Foundry Release API expects a **version-specific** manifest URL in the release request, distinct from the package's own `manifest` field (which should track "latest" for ongoing update detection). This action previously forwarded `manifestFileData.manifest` verbatim. Now it reconstructs the per-version URL:

- Free/public modules → immutable GitHub release-asset URL
- Protected modules → versioned path in the public content repo

Protected packages are **auto-detected** from the released manifest's `protected: true`, so **no per-module workflow change is required**. Adds an optional `publicRepositoryAndBranch` input (default `foundryvtt-dcc/dcc-content/main`).

## Why
Part of moving the in-file `manifest` field to a stable "latest" URL (see companion PRs in `foundry-release-action` and `foundry-manifest-update-action`). Foundry's [Package Release API docs](https://foundryvtt.com/article/package-release-api/) state the API manifest URL "should point to a specific release," not the package's latest-tracking field.

## ⚠️ Merge order
Merge this **before or together with** `foundry-release-action#stable-manifest-url`. Never merge the stable-manifest change first — until this lands, that action would feed a stable URL into the Release API.

This change is behavior-preserving on its own (it reconstructs the same versioned URL the file currently carries), so it is safe to merge first.

## Verification
`node --check` + `standard` pass. Recommend one `dry-run: true` release to confirm Foundry accepts the request before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)